### PR TITLE
Filling public properties

### DIFF
--- a/src/ForeverFactory/ForeverFactory.csproj
+++ b/src/ForeverFactory/ForeverFactory.csproj
@@ -6,10 +6,10 @@
         <Authors>Dyego Alekssander Maas</Authors>
         <Copyright>Copyright Dyego Alekssander Maas</Copyright>
         <PackageId>ForeverFactory</PackageId>
-        <Description>Forever Factory makes it super easy to build many customized objects.</Description>
+        <Description>Forever Factory makes it super easy to build many customized objects. You can define factories for your objects, with all the default values you'll need, or create one on the fly. In each test, you can further customize the objects usings lambdas to override public properties and fields like strings, ints, floats, etc.</Description>
         <PackageProjectUrl>https://github.com/DyegoMaas/ForeverFactory</PackageProjectUrl>
         <RepositoryUrl>https://github.com/DyegoMaas/ForeverFactory</RepositoryUrl>
-        <PackageTags>ForeverFactory factory builder</PackageTags>
+        <PackageTags>ForeverFactory factory builder TDD unit-testing unittesting unitesting testing fluent</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <MinVerTagPrefix>v</MinVerTagPrefix>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/ForeverFactory/Generators/Transforms/Factories/BaseRecursiveTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/BaseRecursiveTransformFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using ForeverFactory.Generators.Transforms.Factories.ReflectionTargets;
 
 namespace ForeverFactory.Generators.Transforms.Factories
 {
@@ -70,51 +71,6 @@ namespace ForeverFactory.Generators.Transforms.Factories
         private bool CanApplyRecursion(TargetInfo targetInfo)
         {
             return _options.EnableRecursiveInstantiation && targetInfo.TargetType != typeof(string);
-        }
-    }
-    
-    internal abstract class TargetInfo
-    {
-        public abstract Type TargetType { get; }
-        public abstract string Name { get; }
-            
-        public abstract void SetValue(object instance, object value);
-    };
-
-    internal sealed class PropertyTargetInfo : TargetInfo
-    {
-        private readonly PropertyInfo _propertyInfo;
-
-        public override Type TargetType => _propertyInfo.PropertyType;
-        public override string Name => _propertyInfo.Name;
-            
-
-        public PropertyTargetInfo(PropertyInfo propertyInfo)
-        {
-            _propertyInfo = propertyInfo;
-        }
-
-        public override void SetValue(object instance, object value)
-        {
-            _propertyInfo.SetValue(instance, value);
-        }
-    }
-        
-    internal sealed class FieldTargetInfo : TargetInfo
-    {
-        private readonly FieldInfo _fieldInfo;
-            
-        public override Type TargetType => _fieldInfo.FieldType;
-        public override string Name => _fieldInfo.Name;
-
-        public FieldTargetInfo(FieldInfo fieldInfo)
-        {
-            _fieldInfo = fieldInfo;
-        }
-
-        public override void SetValue(object instance, object value)
-        {
-            _fieldInfo.SetValue(instance, value);
         }
     }
 }

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithEmptyStringTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithEmptyStringTransformFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ForeverFactory.Generators.Transforms.Factories.ReflectionTargets;
 
 namespace ForeverFactory.Generators.Transforms.Factories
 {

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithEmptyStringTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithEmptyStringTransformFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 
 namespace ForeverFactory.Generators.Transforms.Factories
 {
@@ -10,9 +9,9 @@ namespace ForeverFactory.Generators.Transforms.Factories
         {
         }
 
-        protected override Func<object> GetBuildFunctionForSpecializedProperty(PropertyInfo propertyInfo, int index)
+        protected override Func<object> GetBuildFunctionForSpecializedProperty(TargetInfo targetInfo, int index)
         {
-            if (propertyInfo.PropertyType == typeof(string)) 
+            if (targetInfo.TargetType == typeof(string)) 
                 return () => string.Empty;
 
             return null;

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ForeverFactory.Generators.Transforms.Factories.ReflectionTargets;
 
 namespace ForeverFactory.Generators.Transforms.Factories
 {

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 
 namespace ForeverFactory.Generators.Transforms.Factories
 {
@@ -10,14 +9,14 @@ namespace ForeverFactory.Generators.Transforms.Factories
         {
         }
 
-        protected override Func<object> GetBuildFunctionForSpecializedProperty(PropertyInfo propertyInfo, int index)
+        protected override Func<object> GetBuildFunctionForSpecializedProperty(TargetInfo targetInfo, int index)
         {
             var sequentialNumber = index + 1;
             
-            if (propertyInfo.PropertyType == typeof(string)) 
-                return () => propertyInfo.Name + sequentialNumber;
+            if (targetInfo.TargetType == typeof(string)) 
+                return () => targetInfo.Name + sequentialNumber;
             
-            if (propertyInfo.PropertyType == typeof(byte))
+            if (targetInfo.TargetType == typeof(byte))
                 return () =>
                 {
                     if (sequentialNumber > byte.MaxValue)
@@ -25,7 +24,7 @@ namespace ForeverFactory.Generators.Transforms.Factories
                     return (byte)sequentialNumber;
                 };
             
-            if (propertyInfo.PropertyType == typeof(short))
+            if (targetInfo.TargetType == typeof(short))
                 return () =>
                 {
                     if (sequentialNumber > short.MaxValue)
@@ -33,7 +32,7 @@ namespace ForeverFactory.Generators.Transforms.Factories
                     return (short)sequentialNumber;
                 };
             
-            if (propertyInfo.PropertyType == typeof(ushort))
+            if (targetInfo.TargetType == typeof(ushort))
                 return () =>
                 {
                     if (sequentialNumber > ushort.MaxValue)
@@ -41,25 +40,25 @@ namespace ForeverFactory.Generators.Transforms.Factories
                     return (ushort)sequentialNumber;
                 };
             
-            if (propertyInfo.PropertyType == typeof(int))
+            if (targetInfo.TargetType == typeof(int))
                 return () => sequentialNumber;
             
-            if (propertyInfo.PropertyType == typeof(uint))
+            if (targetInfo.TargetType == typeof(uint))
                 return () => (uint)sequentialNumber;
             
-            if (propertyInfo.PropertyType == typeof(long))
+            if (targetInfo.TargetType == typeof(long))
                 return () => sequentialNumber;
             
-            if (propertyInfo.PropertyType == typeof(ulong))
+            if (targetInfo.TargetType == typeof(ulong))
                 return () => (ulong)sequentialNumber;
             
-            if (propertyInfo.PropertyType == typeof(float))
+            if (targetInfo.TargetType == typeof(float))
                 return () => sequentialNumber;
             
-            if (propertyInfo.PropertyType == typeof(double))
+            if (targetInfo.TargetType == typeof(double))
                 return () => sequentialNumber;
             
-            if (propertyInfo.PropertyType == typeof(decimal))
+            if (targetInfo.TargetType == typeof(decimal))
                 return () => Convert.ToDecimal(sequentialNumber);
 
             return null;

--- a/src/ForeverFactory/Generators/Transforms/Factories/ReflectionTargets/FieldTargetInfo.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/ReflectionTargets/FieldTargetInfo.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+
+namespace ForeverFactory.Generators.Transforms.Factories.ReflectionTargets
+{
+    internal sealed class FieldTargetInfo : TargetInfo
+    {
+        private readonly FieldInfo _fieldInfo;
+            
+        public override Type TargetType => _fieldInfo.FieldType;
+        public override string Name => _fieldInfo.Name;
+
+        public FieldTargetInfo(FieldInfo fieldInfo)
+        {
+            _fieldInfo = fieldInfo;
+        }
+
+        public override void SetValue(object instance, object value)
+        {
+            _fieldInfo.SetValue(instance, value);
+        }
+    }
+}

--- a/src/ForeverFactory/Generators/Transforms/Factories/ReflectionTargets/PropertyTargetInfo.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/ReflectionTargets/PropertyTargetInfo.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reflection;
+
+namespace ForeverFactory.Generators.Transforms.Factories.ReflectionTargets
+{
+    internal sealed class PropertyTargetInfo : TargetInfo
+    {
+        private readonly PropertyInfo _propertyInfo;
+
+        public override Type TargetType => _propertyInfo.PropertyType;
+        public override string Name => _propertyInfo.Name;
+            
+
+        public PropertyTargetInfo(PropertyInfo propertyInfo)
+        {
+            _propertyInfo = propertyInfo;
+        }
+
+        public override void SetValue(object instance, object value)
+        {
+            _propertyInfo.SetValue(instance, value);
+        }
+    }
+}

--- a/src/ForeverFactory/Generators/Transforms/Factories/ReflectionTargets/TargetInfo.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/ReflectionTargets/TargetInfo.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ForeverFactory.Generators.Transforms.Factories.ReflectionTargets
+{
+    internal abstract class TargetInfo
+    {
+        public abstract Type TargetType { get; }
+        public abstract string Name { get; }
+            
+        public abstract void SetValue(object instance, object value);
+    };
+}

--- a/tests/ForeverFactory.Tests/Generators/Transforms/Factories/RecursiveTransformFactoryTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/Transforms/Factories/RecursiveTransformFactoryTests.cs
@@ -1,0 +1,50 @@
+﻿using FluentAssertions;
+using ForeverFactory.Generators.Transforms.Factories;
+using Xunit;
+
+namespace ForeverFactory.Tests.Generators.Transforms.Factories;
+
+public class RecursiveTransformFactoryTests
+{
+    [Fact]
+    public void It_should_build_a_function_that_recursively_sets_all_public_properties_and_fields_to_an_empty_value()
+    {
+        var transform = new FillWithEmptyStringTransformFactory().GetTransform<ClassA>();
+
+        var instanceOfA = new ClassA();
+        transform.ApplyTo(instanceOfA);
+
+        instanceOfA.PublicProperty.Should().Be(string.Empty);
+        instanceOfA.PublicField.Should().Be(string.Empty);
+        instanceOfA.B.Should().NotBeNull();
+
+        var instanceOfB = instanceOfA.B;
+        instanceOfB.PropertyY.Should().Be(string.Empty);
+        instanceOfB.PublicField.Should().Be(string.Empty);
+        instanceOfB.C.Should().NotBeNull();
+            
+        var instanceOfC = instanceOfB.C;
+        instanceOfC.PropertyZ.Should().Be(string.Empty);
+        instanceOfC.PublicField.Should().Be(string.Empty);
+    }
+
+    private class ClassA
+    {
+        public string PublicProperty { get; set; }
+        public string PublicField;
+        public ClassB B { get; set; }
+    }
+
+    private class ClassB
+    {
+        public string PropertyY { get; set; }
+        public string PublicField;
+        public ClassC C { get; set; }
+    }
+    
+    private class ClassC
+    {
+        public string PropertyZ { get; set; }
+        public string PublicField;
+    }
+}


### PR DESCRIPTION
# Features

- Added support to filling public fields, in the addition to public properties, that were already supported.

## Previous behavior: 

```csharp
    private class ClassA
    {
        public string PublicProperty { get; set; } // was already setting
        public string PublicField; // would remain null
    }
```

This was true for all behaviors that depend on recursive traversal:

- FillWithEmptyValuesBehavior
- FillWithSequentialValuesBehavior

## New behavior

```csharp
    private class ClassA
    {
        public string PublicProperty { get; set; } // was already setting
        public string PublicField; // will set value as expected
    }
```