### PR TITLE
Feature/deferred build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ dotnet stryker
 
 ## Roadmap
 
+- Support DateTime in the Sequential generator
+- Support initializing nullable types
 - Allow to configure custom builder per builder (single builder and many builder)
 - Support custom constructor scoped by builder (for now, custom constructors are shared along the linked builders)
 - Support "smart" behavior, which identifies by convention which type of sequences and rules to apply to every property 

--- a/src/ForeverFactory/Behaviors/Behavior.cs
+++ b/src/ForeverFactory/Behaviors/Behavior.cs
@@ -8,7 +8,7 @@ namespace ForeverFactory.Behaviors
     /// </summary>
     public abstract class Behavior
     {
-        public abstract IEnumerable<Transform<T>> GetTransforms<T>()
+        internal abstract IEnumerable<Transform<T>> GetTransforms<T>()
             where T : class;
     }
 }

--- a/src/ForeverFactory/Behaviors/DoNotFillBehavior.cs
+++ b/src/ForeverFactory/Behaviors/DoNotFillBehavior.cs
@@ -10,7 +10,7 @@ namespace ForeverFactory.Behaviors
     /// </summary>
     public class DoNotFillBehavior : Behavior
     {
-        public override IEnumerable<Transform<T>> GetTransforms<T>()
+        internal override IEnumerable<Transform<T>> GetTransforms<T>()
         {
             return Enumerable.Empty<Transform<T>>();
         }

--- a/src/ForeverFactory/Behaviors/FillWithEmptyValuesBehavior.cs
+++ b/src/ForeverFactory/Behaviors/FillWithEmptyValuesBehavior.cs
@@ -24,7 +24,7 @@ namespace ForeverFactory.Behaviors
             };
         }
 
-        public override IEnumerable<Transform<T>> GetTransforms<T>()
+        internal override IEnumerable<Transform<T>> GetTransforms<T>()
         {
             var factory = new FillWithEmptyStringTransformFactory(_recursiveTransformFactoryOptions);
             yield return factory.GetTransform<T>();

--- a/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
+++ b/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
@@ -34,7 +34,7 @@ namespace ForeverFactory.Behaviors
             };
         }
         
-        public override IEnumerable<Transform<T>> GetTransforms<T>()
+        internal override IEnumerable<Transform<T>> GetTransforms<T>()
         {
             var factory = new FillWithSequentialValuesTransformFactory(_recursiveTransformFactoryOptions);
             yield return factory.GetTransform<T>();

--- a/src/ForeverFactory/Customizations/CustomizeFactoryOptions.cs
+++ b/src/ForeverFactory/Customizations/CustomizeFactoryOptions.cs
@@ -1,34 +1,56 @@
 ﻿using System;
+using System.Collections.Generic;
 using ForeverFactory.Behaviors;
+using ForeverFactory.Generators;
+using ForeverFactory.Generators.Transforms;
 
 namespace ForeverFactory.Customizations
 {
-    public class CustomizeFactoryOptions<T> : ICustomizeFactoryOptions<T>
+    public class CustomizeFactoryOptions<T> : ICustomizeFactoryOptions<T>, IObjectFactoryOptions<T>
         where T : class
     {
-        private readonly MagicFactory<T> _magicFactory;
-
-        public CustomizeFactoryOptions(MagicFactory<T> magicFactory)
+        // private readonly MagicFactory<T> _magicFactory;
+        //
+        public CustomizeFactoryOptions()
         {
-            _magicFactory = magicFactory;
+            // _magicFactory = magicFactory;
+            Transforms = new List<Transform<T>>();
+            SelectedBehavior = new DoNotFillBehavior();
         }
+
+        public Func<T> CustomConstructor { get; private set; }
+        public IList<Transform<T>> Transforms { get; }
+        public Behavior SelectedBehavior { get; private set; }
 
         public ICustomizeFactoryOptions<T> UseConstructor(Func<T> customConstructor)
         {
-            _magicFactory.UsingConstructor(customConstructor);
+            // _magicFactory.UsingConstructor(customConstructor);
+            CustomConstructor = customConstructor;
             return this;
         }
 
         public ICustomizeFactoryOptions<T> Set<TValue>(Func<T, TValue> setMember)
         {
-            _magicFactory.AddDefaultTransform(setMember);
+            // _magicFactory.AddDefaultTransform(setMember);
+            Transforms.Add(new FuncTransform<T, TValue>(setMember.Invoke));
             return this;
         }
 
         public ICustomizeFactoryOptions<T> SetDefaultBehavior(Behavior behavior)
         {
-            _magicFactory.WithBehavior(behavior);
+            // _magicFactory.WithBehavior(behavior);
+            SelectedBehavior = behavior;
             return this;
+        }
+
+        public void UpdateConstructor(Func<T> customConstructor)
+        {
+            CustomConstructor = customConstructor;
+        }
+
+        public void UpdateBehavior(Behavior behavior)
+        {
+            SelectedBehavior = behavior;
         }
     }
 }

--- a/src/ForeverFactory/Customizations/CustomizeFactoryOptions.cs
+++ b/src/ForeverFactory/Customizations/CustomizeFactoryOptions.cs
@@ -6,22 +6,18 @@ using ForeverFactory.Generators.Transforms;
 
 namespace ForeverFactory.Customizations
 {
-    public class CustomizeFactoryOptions<T> : ICustomizeFactoryOptions<T>, IObjectFactoryOptions<T>
+    internal class CustomizeFactoryOptions<T> : ICustomizeFactoryOptions<T>, IObjectFactoryOptions<T>
         where T : class
     {
-        private readonly List<Transform<T>> _transforms;
-        
         public CustomizeFactoryOptions()
         {
-            _transforms = new List<Transform<T>>();
+            Transforms = new List<Transform<T>>();
             SelectedBehavior = new DoNotFillBehavior();
         }
 
         public Func<T> CustomConstructor { get; private set; }
-
-        public IReadOnlyCollection<Transform<T>> Transforms => _transforms.AsReadOnly();
-
         public Behavior SelectedBehavior { get; private set; }
+        public IList<Transform<T>> Transforms { get; }
 
         public ICustomizeFactoryOptions<T> UseConstructor(Func<T> customConstructor)
         {
@@ -31,7 +27,7 @@ namespace ForeverFactory.Customizations
 
         public ICustomizeFactoryOptions<T> Set<TValue>(Func<T, TValue> setMember)
         {
-            _transforms.Add(new FuncTransform<T, TValue>(setMember.Invoke));
+            Transforms.Add(new FuncTransform<T, TValue>(setMember.Invoke));
             return this;
         }
 

--- a/src/ForeverFactory/Customizations/CustomizeFactoryOptions.cs
+++ b/src/ForeverFactory/Customizations/CustomizeFactoryOptions.cs
@@ -9,46 +9,44 @@ namespace ForeverFactory.Customizations
     public class CustomizeFactoryOptions<T> : ICustomizeFactoryOptions<T>, IObjectFactoryOptions<T>
         where T : class
     {
-        // private readonly MagicFactory<T> _magicFactory;
-        //
+        private readonly List<Transform<T>> _transforms;
+        
         public CustomizeFactoryOptions()
         {
-            // _magicFactory = magicFactory;
-            Transforms = new List<Transform<T>>();
+            _transforms = new List<Transform<T>>();
             SelectedBehavior = new DoNotFillBehavior();
         }
 
         public Func<T> CustomConstructor { get; private set; }
-        public IList<Transform<T>> Transforms { get; }
+
+        public IReadOnlyCollection<Transform<T>> Transforms => _transforms.AsReadOnly();
+
         public Behavior SelectedBehavior { get; private set; }
 
         public ICustomizeFactoryOptions<T> UseConstructor(Func<T> customConstructor)
         {
-            // _magicFactory.UsingConstructor(customConstructor);
             CustomConstructor = customConstructor;
             return this;
         }
 
         public ICustomizeFactoryOptions<T> Set<TValue>(Func<T, TValue> setMember)
         {
-            // _magicFactory.AddDefaultTransform(setMember);
-            Transforms.Add(new FuncTransform<T, TValue>(setMember.Invoke));
+            _transforms.Add(new FuncTransform<T, TValue>(setMember.Invoke));
             return this;
         }
 
         public ICustomizeFactoryOptions<T> SetDefaultBehavior(Behavior behavior)
         {
-            // _magicFactory.WithBehavior(behavior);
             SelectedBehavior = behavior;
             return this;
         }
 
-        public void UpdateConstructor(Func<T> customConstructor)
+        internal void UpdateConstructor(Func<T> customConstructor)
         {
             CustomConstructor = customConstructor;
         }
 
-        public void UpdateBehavior(Behavior behavior)
+        internal void UpdateBehavior(Behavior behavior)
         {
             SelectedBehavior = behavior;
         }

--- a/src/ForeverFactory/Generators/GeneratorNode.cs
+++ b/src/ForeverFactory/Generators/GeneratorNode.cs
@@ -34,7 +34,7 @@ namespace ForeverFactory.Generators
             _customConstructor = newCustomConstructor;
         }
 
-        public IEnumerable<T> ProduceInstances(IEnumerable<NotGuardedTransform<T>> defaultTransforms = null)
+        public IEnumerable<T> GenerateInstances(IEnumerable<NotGuardedTransform<T>> defaultTransforms = null)
         {
             for (var index = 0; index < TargetCount; index++)
             {

--- a/src/ForeverFactory/Generators/GeneratorNode.cs
+++ b/src/ForeverFactory/Generators/GeneratorNode.cs
@@ -11,17 +11,15 @@ namespace ForeverFactory.Generators
         where T : class
     {
         private readonly List<GuardedTransform<T>> _transformsToApply = new List<GuardedTransform<T>>();
-        private Func<T> _customConstructor;
+        // private Func<T> _customConstructor;
 
-        public GeneratorNode(
-            int targetCount = 1,
-            Func<T> customConstructor = null)
+        public GeneratorNode(int instanceCount = 1)
         {
-            TargetCount = targetCount;
-            _customConstructor = customConstructor;
+            InstanceCount = instanceCount;
+            // _customConstructor = customConstructor;
         }
 
-        public int TargetCount { get; }
+        public int InstanceCount { get; }
 
         public void AddTransform(Transform<T> transform, CanApplyTransformSpecification guard = null)
         {
@@ -29,16 +27,16 @@ namespace ForeverFactory.Generators
             _transformsToApply.Add(new GuardedTransform<T>(transform, guard));
         }
 
-        public void OverrideCustomConstructor(Func<T> newCustomConstructor)
-        {
-            _customConstructor = newCustomConstructor;
-        }
+        // public void OverrideCustomConstructor(Func<T> newCustomConstructor)
+        // {
+        //     _customConstructor = newCustomConstructor;
+        // }
 
-        public IEnumerable<T> GenerateInstances(IEnumerable<NotGuardedTransform<T>> defaultTransforms = null)
+        public IEnumerable<T> GenerateInstances(IEnumerable<NotGuardedTransform<T>> defaultTransforms = null, Func<T> customConstructor = null)
         {
-            for (var index = 0; index < TargetCount; index++)
+            for (var index = 0; index < InstanceCount; index++)
             {
-                var instance = CreateInstance();
+                var instance = CreateInstance(customConstructor);
 
                 var defaultTransformsToApply = defaultTransforms ?? Enumerable.Empty<GuardedTransform<T>>();
                 var transformsToApply = defaultTransformsToApply.Union(_transformsToApply);
@@ -48,10 +46,10 @@ namespace ForeverFactory.Generators
             }
         }
 
-        private T CreateInstance()
+        private T CreateInstance(Func<T> customConstructor = null)
         {
-            return _customConstructor != null
-                ? _customConstructor.Invoke()
+            return customConstructor != null
+                ? customConstructor.Invoke()
                 : Activator.CreateInstance<T>();
         }
 

--- a/src/ForeverFactory/Generators/GeneratorNode.cs
+++ b/src/ForeverFactory/Generators/GeneratorNode.cs
@@ -11,12 +11,10 @@ namespace ForeverFactory.Generators
         where T : class
     {
         private readonly List<GuardedTransform<T>> _transformsToApply = new List<GuardedTransform<T>>();
-        // private Func<T> _customConstructor;
 
         public GeneratorNode(int instanceCount = 1)
         {
             InstanceCount = instanceCount;
-            // _customConstructor = customConstructor;
         }
 
         public int InstanceCount { get; }
@@ -26,11 +24,6 @@ namespace ForeverFactory.Generators
             guard = guard ?? new AlwaysApplyTransformSpecification();
             _transformsToApply.Add(new GuardedTransform<T>(transform, guard));
         }
-
-        // public void OverrideCustomConstructor(Func<T> newCustomConstructor)
-        // {
-        //     _customConstructor = newCustomConstructor;
-        // }
 
         public IEnumerable<T> GenerateInstances(IEnumerable<NotGuardedTransform<T>> defaultTransforms = null, Func<T> customConstructor = null)
         {
@@ -46,14 +39,14 @@ namespace ForeverFactory.Generators
             }
         }
 
-        private T CreateInstance(Func<T> customConstructor = null)
+        private static T CreateInstance(Func<T> customConstructor = null)
         {
             return customConstructor != null
                 ? customConstructor.Invoke()
                 : Activator.CreateInstance<T>();
         }
 
-        private void ApplyTransformsToInstance(IEnumerable<GuardedTransform<T>> guardedTransforms, T instance,
+        private static void ApplyTransformsToInstance(IEnumerable<GuardedTransform<T>> guardedTransforms, T instance,
             int instanceIndex)
         {
             foreach (var guardedTransform in guardedTransforms)

--- a/src/ForeverFactory/Generators/IObjectFactoryOptions.cs
+++ b/src/ForeverFactory/Generators/IObjectFactoryOptions.cs
@@ -5,11 +5,11 @@ using ForeverFactory.Generators.Transforms;
 
 namespace ForeverFactory.Generators
 {
-    public interface IObjectFactoryOptions<T>
+    internal interface IObjectFactoryOptions<T>
         where T : class
     {
         Func<T> CustomConstructor { get; }
-        IReadOnlyCollection<Transform<T>> Transforms { get; }
+        IList<Transform<T>> Transforms { get; }
         Behavior SelectedBehavior { get; }
     }
 }

--- a/src/ForeverFactory/Generators/IObjectFactoryOptions.cs
+++ b/src/ForeverFactory/Generators/IObjectFactoryOptions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using ForeverFactory.Behaviors;
+using ForeverFactory.Generators.Transforms;
+
+namespace ForeverFactory.Generators
+{
+    public interface IObjectFactoryOptions<T>
+        where T : class
+    {
+        Func<T> CustomConstructor { get; }
+        IList<Transform<T>> Transforms { get; }
+        Behavior SelectedBehavior { get; }
+    }
+}

--- a/src/ForeverFactory/Generators/IObjectFactoryOptions.cs
+++ b/src/ForeverFactory/Generators/IObjectFactoryOptions.cs
@@ -9,7 +9,7 @@ namespace ForeverFactory.Generators
         where T : class
     {
         Func<T> CustomConstructor { get; }
-        IList<Transform<T>> Transforms { get; }
+        IReadOnlyCollection<Transform<T>> Transforms { get; }
         Behavior SelectedBehavior { get; }
     }
 }

--- a/src/ForeverFactory/Generators/ObjectFactory.cs
+++ b/src/ForeverFactory/Generators/ObjectFactory.cs
@@ -12,7 +12,6 @@ namespace ForeverFactory.Generators
         where T : class
     {
         private readonly IObjectFactoryOptions<T> _options;
-        // private readonly List<NotGuardedTransform<T>> _defaultTransforms = new List<NotGuardedTransform<T>>();
         private readonly List<GeneratorNode<T>> _generatorNodes = new List<GeneratorNode<T>>();
 
         public ObjectFactory(IObjectFactoryOptions<T> options)
@@ -22,22 +21,14 @@ namespace ForeverFactory.Generators
 
         public IEnumerable<T> Build()
         {
-            var defaultTransforms = _options
-                .SelectedBehavior.GetTransforms<T>()
-                .Union(_options.Transforms)
+            var behaviorTransforms = _options.SelectedBehavior.GetTransforms<T>();
+            var optionsTransforms = _options.Transforms;
+            var notGuardedTransforms = behaviorTransforms
+                .Union(optionsTransforms)
                 .Select(transform => new NotGuardedTransform<T>(transform));
-            // foreach (var transform in defaultTransforms)
-            // {
-            //     _options.AddDefaultTransform(transform);
-            // }
             
-            return _generatorNodes.SelectMany(node => node.GenerateInstances(defaultTransforms, _options.CustomConstructor));
+            return _generatorNodes.SelectMany(node => node.GenerateInstances(notGuardedTransforms, _options.CustomConstructor));
         }
-
-        // public void AddDefaultTransform(Transform<T> transform)
-        // {
-        //     _defaultTransforms.Add(new NotGuardedTransform<T>(transform));
-        // }
 
         public void AddTransform(Transform<T> transform, Func<GeneratorNode<T>, CanApplyTransformSpecification> guard)
         {

--- a/src/ForeverFactory/Generators/ObjectFactory.cs
+++ b/src/ForeverFactory/Generators/ObjectFactory.cs
@@ -12,11 +12,11 @@ namespace ForeverFactory.Generators
         where T : class
     {
         private readonly List<NotGuardedTransform<T>> _defaultTransforms = new List<NotGuardedTransform<T>>();
-        private readonly List<GeneratorNode<T>> _nodes = new List<GeneratorNode<T>>();
+        private readonly List<GeneratorNode<T>> _generatorNodes = new List<GeneratorNode<T>>();
 
         public IEnumerable<T> Build()
         {
-            return _nodes.SelectMany(generatorNode => generatorNode.ProduceInstances(_defaultTransforms));
+            return _generatorNodes.SelectMany(node => node.GenerateInstances(_defaultTransforms));
         }
 
         public void AddDefaultTransform(Transform<T> transform)
@@ -32,20 +32,18 @@ namespace ForeverFactory.Generators
 
         private GeneratorNode<T> GetCurrentGeneratorNode()
         {
-            return _nodes.Any()
-                ? _nodes.Last()
-                : null;
+            return _generatorNodes.LastOrDefault();
         }
 
         public void AddRootNode(GeneratorNode<T> generatorNode)
         {
-            _nodes.Clear();
+            _generatorNodes.Clear();
             AddNode(generatorNode);
         }
 
         public void AddNode(GeneratorNode<T> generatorNode)
         {
-            _nodes.Add(generatorNode);
+            _generatorNodes.Add(generatorNode);
         }
     }
 }

--- a/src/ForeverFactory/Generators/Transforms/Guards/Specifications/AlwaysApplyTransformSpecification.cs
+++ b/src/ForeverFactory/Generators/Transforms/Guards/Specifications/AlwaysApplyTransformSpecification.cs
@@ -2,7 +2,7 @@
 {
     internal class AlwaysApplyTransformSpecification : CanApplyTransformSpecification
     {
-        public override bool CanApply(int currentIndex)
+        public override bool CanApply(int index)
         {
             return true;
         }

--- a/src/ForeverFactory/Generators/Transforms/Guards/Specifications/ApplyTransformToFirstInstancesSpecification.cs
+++ b/src/ForeverFactory/Generators/Transforms/Guards/Specifications/ApplyTransformToFirstInstancesSpecification.cs
@@ -17,9 +17,9 @@ namespace ForeverFactory.Generators.Transforms.Guards.Specifications
             _countToApply = countToApply;
         }
 
-        public override bool CanApply(int currentIndex)
+        public override bool CanApply(int index)
         {
-            return currentIndex < _countToApply;
+            return index < _countToApply;
         }
     }
 }

--- a/src/ForeverFactory/Generators/Transforms/Guards/Specifications/ApplyTransformToLastInstancesSpecification.cs
+++ b/src/ForeverFactory/Generators/Transforms/Guards/Specifications/ApplyTransformToLastInstancesSpecification.cs
@@ -19,10 +19,10 @@ namespace ForeverFactory.Generators.Transforms.Guards.Specifications
             _targetCount = targetCount;
         }
 
-        public override bool CanApply(int currentIndex)
+        public override bool CanApply(int index)
         {
             var firstToApply = _targetCount - _countToApply;
-            return currentIndex >= firstToApply;
+            return index >= firstToApply;
         }
     }
 }

--- a/src/ForeverFactory/Generators/Transforms/Guards/Specifications/CanApplyTransformSpecification.cs
+++ b/src/ForeverFactory/Generators/Transforms/Guards/Specifications/CanApplyTransformSpecification.cs
@@ -2,6 +2,6 @@
 {
     internal abstract class CanApplyTransformSpecification
     {
-        public abstract bool CanApply(int currentIndex);
+        public abstract bool CanApply(int index);
     }
 }

--- a/src/ForeverFactory/MagicFactory.cs
+++ b/src/ForeverFactory/MagicFactory.cs
@@ -42,29 +42,20 @@ namespace ForeverFactory
         where T : class
     {
         private readonly ObjectFactory<T> _objectFactory;
-        // private Func<T> _customConstructor;
-
         private readonly CustomizeFactoryOptions<T> _customizeFactoryOptions;
-        // private GeneratorNode<T> _rootNode;
-        private GeneratorNode<T> _currentNode;
 
         protected MagicFactory()
         {
-            // _rootNode = new GeneratorNode<T>(targetCount: 1, customConstructor: null);
-            // _objectFactory.AddRootNode(_rootNode);
-            
             _customizeFactoryOptions = new CustomizeFactoryOptions<T>();
             _objectFactory = new ObjectFactory<T>(_customizeFactoryOptions);
             Customize(_customizeFactoryOptions);
             SetRootNode(instanceCount: 1);
-            // Customize(new CustomizeFactoryOptions<T>());
         }
         
         private void SetRootNode(int instanceCount)
         {
-            // _currentNode = new GeneratorNode<T>(instanceCount, _customizeFactoryOptions.CustomConstructor);
-            _currentNode = new GeneratorNode<T>(instanceCount);
-            _objectFactory.AddRootNode(_currentNode);
+            var rootNode = new GeneratorNode<T>(instanceCount);
+            _objectFactory.AddRootNode(rootNode);
         }
 
         protected abstract void Customize(ICustomizeFactoryOptions<T> customization);
@@ -72,24 +63,12 @@ namespace ForeverFactory
         public ISimpleFactory<T> UsingConstructor(Func<T> customConstructor)
         {
             _customizeFactoryOptions.UpdateConstructor(customConstructor);
-            // _customConstructor = customConstructor;
-            // _rootNode.OverrideCustomConstructor(customConstructor);
             return this;
         }
-
-        // internal void AddDefaultTransform<TValue>(Func<T, TValue> setMember)
-        // {
-        //     _objectFactory.AddDefaultTransform(new FuncTransform<T,TValue>(setMember.Invoke));
-        // }
 
         public ISimpleFactory<T> WithBehavior(Behavior behavior)
         {
             _customizeFactoryOptions.UpdateBehavior(behavior);
-            // var transforms = behavior.GetTransforms<T>();
-            // foreach (var transform in transforms)
-            // {
-            //     _objectFactory.AddDefaultTransform(transform);
-            // }
             return this;
         }
 
@@ -118,7 +97,6 @@ namespace ForeverFactory
 
         public ICustomizeOneBuildManyWithNavigation<T> PlusOne()
         {
-            // var newNode = new GeneratorNode<T>(instanceCount: 1, _customizeFactoryOptions.CustomConstructor);
             var newNode = new GeneratorNode<T>(instanceCount: 1);
             _objectFactory.AddNode(newNode);
             
@@ -127,7 +105,6 @@ namespace ForeverFactory
 
         public ICustomizeManyBuildMany<T> Plus(int count)
         {
-            // var newNode = new GeneratorNode<T>(instanceCount: count, _customizeFactoryOptions.CustomConstructor);
             var newNode = new GeneratorNode<T>(instanceCount: count);
             _objectFactory.AddNode(newNode);
 
@@ -165,7 +142,7 @@ namespace ForeverFactory
 
         IEnumerable<T> IBuildMany<T>.Build()
         {
-            return BuildObjects();
+            return _objectFactory.Build();
         }
 
         private void AddTransformThatAlwaysApply<TValue>(Func<T, TValue> setMember)
@@ -190,11 +167,6 @@ namespace ForeverFactory
                 new FuncTransform<T, TValue>(setMember.Invoke),
                 node => new ApplyTransformToLastInstancesSpecification(count, node.InstanceCount)
             );
-        }
-
-        private IEnumerable<T> BuildObjects()
-        {
-            return _objectFactory.Build();
         }
     }
 }

--- a/src/ForeverFactory/MagicFactory.cs
+++ b/src/ForeverFactory/MagicFactory.cs
@@ -38,7 +38,7 @@ namespace ForeverFactory
     ///     A customizable factory of objects of type "T". It can be extended with predefined configurations.
     /// </summary>
     /// <typeparam name="T">The type of objects that this factory will build.</typeparam>
-    public abstract class MagicFactory<T> : ISimpleFactory<T>, ICustomizeOneBuildOne<T>, ICustomizeOneBuildOneWithNavigation<T>, ICustomizeManyBuildMany<T>, ICustomizeOneBuildManyWithNavigation<T>
+    public abstract class MagicFactory<T> : ISimpleFactory<T>, ICustomizeOneBuildOneWithNavigation<T>, ICustomizeManyBuildMany<T>, ICustomizeOneBuildManyWithNavigation<T>
         where T : class
     {
         private readonly ObjectFactory<T> _objectFactory = new ObjectFactory<T>();
@@ -50,6 +50,14 @@ namespace ForeverFactory
             SetRootNode(1);
             Customize(new CustomizeFactoryOptions<T>(this));
         }
+        
+        private void SetRootNode(int targetCount)
+        {
+            _rootNode = new GeneratorNode<T>(targetCount, _customConstructor);
+            _objectFactory.AddRootNode(_rootNode);
+        }
+
+        protected abstract void Customize(ICustomizeFactoryOptions<T> customization);
 
         public ISimpleFactory<T> UsingConstructor(Func<T> customConstructor)
         {
@@ -144,14 +152,6 @@ namespace ForeverFactory
         {
             return _objectFactory.Build();
         }
-
-        private void SetRootNode(int targetCount)
-        {
-            _rootNode = new GeneratorNode<T>(targetCount, _customConstructor);
-            _objectFactory.AddRootNode(_rootNode);
-        }
-
-        protected abstract void Customize(ICustomizeFactoryOptions<T> customization);
 
         private void AddTransformThatAlwaysApply<TValue>(Func<T, TValue> setMember)
         {

--- a/src/ForeverFactory/MagicFactory.cs
+++ b/src/ForeverFactory/MagicFactory.cs
@@ -51,14 +51,14 @@ namespace ForeverFactory
             Customize(_customizeFactoryOptions);
             SetRootNode(instanceCount: 1);
         }
-        
+
+        protected abstract void Customize(ICustomizeFactoryOptions<T> customization);
+
         private void SetRootNode(int instanceCount)
         {
             var rootNode = new GeneratorNode<T>(instanceCount);
             _objectFactory.AddRootNode(rootNode);
         }
-
-        protected abstract void Customize(ICustomizeFactoryOptions<T> customization);
 
         public ISimpleFactory<T> UsingConstructor(Func<T> customConstructor)
         {

--- a/tests/ForeverFactory.Tests/Generators/GeneratorNodeTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/GeneratorNodeTests.cs
@@ -37,9 +37,7 @@ namespace ForeverFactory.Tests.Generators
         [Fact]
         public void It_should_accept_a_custom_constructor_function()
         {
-            var generatorNode = new GeneratorNode<Person>(
-                // customConstructor: () => new Person {FirstName = "John", LastName = "Doe"}
-            );
+            var generatorNode = new GeneratorNode<Person>();
 
             var persons = generatorNode.GenerateInstances(customConstructor: () => new Person {FirstName = "John", LastName = "Doe"});
 
@@ -135,16 +133,5 @@ namespace ForeverFactory.Tests.Generators
 
             targetCount.Should().Be(3);
         }
-
-        // [Fact]
-        // public void It_should_override_the_custom_constructor()
-        // {
-        //     var generatorNode = new GeneratorNode<Person>(1, () => new Person {Age = 10});
-        //
-        //     generatorNode.OverrideCustomConstructor(() => new Person {Age = 11});
-        //
-        //     var person = generatorNode.GenerateInstances().First();
-        //     person.Age.Should().Be(11);
-        // }
     }
 }

--- a/tests/ForeverFactory.Tests/Generators/GeneratorNodeTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/GeneratorNodeTests.cs
@@ -38,10 +38,10 @@ namespace ForeverFactory.Tests.Generators
         public void It_should_accept_a_custom_constructor_function()
         {
             var generatorNode = new GeneratorNode<Person>(
-                customConstructor: () => new Person {FirstName = "John", LastName = "Doe"}
+                // customConstructor: () => new Person {FirstName = "John", LastName = "Doe"}
             );
 
-            var persons = generatorNode.GenerateInstances();
+            var persons = generatorNode.GenerateInstances(customConstructor: () => new Person {FirstName = "John", LastName = "Doe"});
 
             foreach (var person in persons)
             {
@@ -68,9 +68,7 @@ namespace ForeverFactory.Tests.Generators
         [Fact]
         public void It_should_apply_transforms_with_guards()
         {
-            var generatorNode = new GeneratorNode<Person>(5,
-                () => new Person {FirstName = "Anne"}
-            );
+            var generatorNode = new GeneratorNode<Person>(5);
             generatorNode.AddTransform(
                 new FuncTransform<Person, string>(x => x.FirstName = "Martha"),
                 new ApplyTransformToFirstInstancesSpecification(countToApply: 2, targetCount: 5)
@@ -80,7 +78,9 @@ namespace ForeverFactory.Tests.Generators
                 new ApplyTransformToLastInstancesSpecification(countToApply: 2, targetCount: 5)
             );
 
-            var persons = generatorNode.GenerateInstances().ToArray();
+            var persons = generatorNode
+                .GenerateInstances(customConstructor: () => new Person {FirstName = "Anne"})
+                .ToArray();
 
             var firstNames = persons.Select(x => x.FirstName);
             firstNames.Should().BeEquivalentTo("Martha", "Martha", "Anne", "Mirage", "Mirage");
@@ -131,20 +131,20 @@ namespace ForeverFactory.Tests.Generators
         {
             var generatorNode = new GeneratorNode<Person>(3);
 
-            var targetCount = generatorNode.TargetCount;
+            var targetCount = generatorNode.InstanceCount;
 
             targetCount.Should().Be(3);
         }
 
-        [Fact]
-        public void It_should_override_the_custom_constructor()
-        {
-            var generatorNode = new GeneratorNode<Person>(1, () => new Person {Age = 10});
-
-            generatorNode.OverrideCustomConstructor(() => new Person {Age = 11});
-
-            var person = generatorNode.GenerateInstances().First();
-            person.Age.Should().Be(11);
-        }
+        // [Fact]
+        // public void It_should_override_the_custom_constructor()
+        // {
+        //     var generatorNode = new GeneratorNode<Person>(1, () => new Person {Age = 10});
+        //
+        //     generatorNode.OverrideCustomConstructor(() => new Person {Age = 11});
+        //
+        //     var person = generatorNode.GenerateInstances().First();
+        //     person.Age.Should().Be(11);
+        // }
     }
 }

--- a/tests/ForeverFactory.Tests/Generators/GeneratorNodeTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/GeneratorNodeTests.cs
@@ -16,7 +16,7 @@ namespace ForeverFactory.Tests.Generators
         {
             var generatorNode = new GeneratorNode<Person>();
 
-            var instances = generatorNode.ProduceInstances();
+            var instances = generatorNode.GenerateInstances();
 
             instances.Should().HaveCount(1);
         }
@@ -29,7 +29,7 @@ namespace ForeverFactory.Tests.Generators
         {
             var generatorNode = new GeneratorNode<Person>(targetCount);
 
-            var instances = generatorNode.ProduceInstances();
+            var instances = generatorNode.GenerateInstances();
 
             instances.Should().HaveCount(targetCount);
         }
@@ -41,7 +41,7 @@ namespace ForeverFactory.Tests.Generators
                 customConstructor: () => new Person {FirstName = "John", LastName = "Doe"}
             );
 
-            var persons = generatorNode.ProduceInstances();
+            var persons = generatorNode.GenerateInstances();
 
             foreach (var person in persons)
             {
@@ -60,7 +60,7 @@ namespace ForeverFactory.Tests.Generators
                 new AlwaysApplyTransformSpecification()
             );
 
-            var persons = generatorNode.ProduceInstances();
+            var persons = generatorNode.GenerateInstances();
 
             foreach (var person in persons) person.FirstName.Should().Be("Martha");
         }
@@ -80,7 +80,7 @@ namespace ForeverFactory.Tests.Generators
                 new ApplyTransformToLastInstancesSpecification(countToApply: 2, targetCount: 5)
             );
 
-            var persons = generatorNode.ProduceInstances().ToArray();
+            var persons = generatorNode.GenerateInstances().ToArray();
 
             var firstNames = persons.Select(x => x.FirstName);
             firstNames.Should().BeEquivalentTo("Martha", "Martha", "Anne", "Mirage", "Mirage");
@@ -95,7 +95,7 @@ namespace ForeverFactory.Tests.Generators
                 new NotGuardedTransform<Person>(new FuncTransform<Person, string>(x => x.FirstName = "Martha"));
             var transform2 =
                 new NotGuardedTransform<Person>(new FuncTransform<Person, string>(x => x.LastName = "Kane"));
-            var persons = generatorNode.ProduceInstances(new[] {transform1, transform2});
+            var persons = generatorNode.GenerateInstances(new[] {transform1, transform2});
 
             foreach (var person in persons)
             {
@@ -117,7 +117,7 @@ namespace ForeverFactory.Tests.Generators
                 new NotGuardedTransform<Person>(new FuncTransform<Person, string>(x => x.FirstName = "Martha"));
             var transform2 =
                 new NotGuardedTransform<Person>(new FuncTransform<Person, string>(x => x.LastName = "Kane"));
-            var persons = generatorNode.ProduceInstances(new[] {transform1, transform2});
+            var persons = generatorNode.GenerateInstances(new[] {transform1, transform2});
 
             foreach (var person in persons)
             {
@@ -143,7 +143,7 @@ namespace ForeverFactory.Tests.Generators
 
             generatorNode.OverrideCustomConstructor(() => new Person {Age = 11});
 
-            var person = generatorNode.ProduceInstances().First();
+            var person = generatorNode.GenerateInstances().First();
             person.Age.Should().Be(11);
         }
     }


### PR DESCRIPTION
# Deferred Configuration

The `CustomizeFactoryOptions<T>` class now keeps track of imporant customizations by the user, as the default setters configured in extended factories, custom constructors and selected behavior.

This change was fundamental to cleaning up some messy initialization code that was scattered all around the `MagicFactory<T>` class. With this change, `MagicFactory<T>` is now much easier to read and comprehend.

```csharp
public abstract class MagicFactory<T> : ISimpleFactory<T>, ICustomizeOneBuildOneWithNavigation<T>, ICustomizeManyBuildMany<T>, ICustomizeOneBuildManyWithNavigation<T>
    where T : class
{
    private readonly ObjectFactory<T> _objectFactory;
    private readonly CustomizeFactoryOptions<T> _customizeFactoryOptions;

    protected MagicFactory()
    {
        _customizeFactoryOptions = new CustomizeFactoryOptions<T>();
        _objectFactory = new ObjectFactory<T>(_customizeFactoryOptions);
        Customize(_customizeFactoryOptions);
        SetRootNode(instanceCount: 1);
    }

    protected abstract void Customize(ICustomizeFactoryOptions<T> customization);
//...
```

The build process now has full control on how to assembly instances.

```csharp
public IEnumerable<T> Build()
{
    var behaviorTransforms = _options.SelectedBehavior.GetTransforms<T>();
    var optionsTransforms = _options.Transforms;
    var notGuardedTransforms = behaviorTransforms
        .Union(optionsTransforms)
        .Select(transform => new NotGuardedTransform<T>(transform));
    
    return _generatorNodes.SelectMany(node => node.GenerateInstances(notGuardedTransforms, _options.CustomConstructor));
}
```