### PR TITLE
Added support to DateTime in FillWithSequentialValuesBehavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ dotnet stryker
 
 ## Roadmap
 
-- Support DateTime in the Sequential generator
 - Support initializing nullable types
 - Allow to configure custom builder per builder (single builder and many builder)
 - Support custom constructor scoped by builder (for now, custom constructors are shared along the linked builders)

--- a/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
+++ b/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
@@ -53,6 +53,7 @@ namespace ForeverFactory.Behaviors
     public enum DateTimeIncrements
     {
         Days = 1,
-        Months = 2
+        Months = 2,
+        Years = 3
     }
 }

--- a/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
+++ b/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
@@ -52,8 +52,13 @@ namespace ForeverFactory.Behaviors
     
     public enum DateTimeIncrements
     {
-        Days = 1,
+        Years = 1,
         Months = 2,
-        Years = 3
+        Days = 3,
+        Hours = 4,
+        Minutes = 5,
+        Seconds = 6,
+        Milliseconds = 7,
+        Ticks = 8
     }
 }

--- a/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
+++ b/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
@@ -30,7 +30,9 @@ namespace ForeverFactory.Behaviors
 
             _recursiveTransformFactoryOptions = new RecursiveTransformFactoryOptions
             {
-                EnableRecursiveInstantiation = configuration.Recursive
+                EnableRecursiveInstantiation = configuration.Recursive,
+                DateTimeIncrements = configuration.DateTimeOptions?.DateTimeIncrements ?? DateTimeIncrements.Days,
+                StartDate = configuration.DateTimeOptions?.StartDate ?? RecursiveTransformFactoryOptions.DefaultStartDate
             };
         }
         
@@ -48,6 +50,27 @@ namespace ForeverFactory.Behaviors
         /// Default is true.
         /// </summary>
         public bool Recursive { get; set; } = true;
+
+        /// <summary>
+        /// Allows customizing how DateTimes are generated.
+        /// </summary>
+        public DateTimeSequenceOptions DateTimeOptions { get; set; }
+    }
+
+    public class DateTimeSequenceOptions
+    {
+        /// <summary>
+        /// Dates will be generated sequentially, starting from StartDate in increments determined by DateTimeIncrements
+        /// property.
+        /// Optional. Default value is 1753/1/1.
+        /// </summary>
+        public DateTime? StartDate { get; set; }
+        
+        /// <summary>
+        /// Determines by how much each instance will variate from the previous.
+        /// Default value is DateTimeIncrements.Days.
+        /// </summary>
+        public DateTimeIncrements DateTimeIncrements { get; set; } = DateTimeIncrements.Days;
     }
     
     public enum DateTimeIncrements

--- a/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
+++ b/src/ForeverFactory/Behaviors/FillWithSequentialValuesBehavior.cs
@@ -49,4 +49,10 @@ namespace ForeverFactory.Behaviors
         /// </summary>
         public bool Recursive { get; set; } = true;
     }
+    
+    public enum DateTimeIncrements
+    {
+        Days = 1,
+        Months = 2
+    }
 }

--- a/src/ForeverFactory/Generators/Transforms/Factories/BaseRecursiveTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/BaseRecursiveTransformFactory.cs
@@ -7,11 +7,11 @@ namespace ForeverFactory.Generators.Transforms.Factories
 {
     internal abstract class BaseRecursiveTransformFactory : ITranformFactory
     {
-        private readonly RecursiveTransformFactoryOptions _options;
+        protected readonly RecursiveTransformFactoryOptions Options;
 
         protected BaseRecursiveTransformFactory(RecursiveTransformFactoryOptions options = null)
         {
-            _options = options ?? new RecursiveTransformFactoryOptions();
+            Options = options ?? new RecursiveTransformFactoryOptions();
         }
 
         public Transform<T> GetTransform<T>()
@@ -54,7 +54,7 @@ namespace ForeverFactory.Generators.Transforms.Factories
             if (buildFunction != null)
                 return buildFunction;
 
-            if (_options.EnableRecursiveInstantiation is false)
+            if (Options.EnableRecursiveInstantiation is false)
                 return null;
 
             var parameterlessConstructor = targetInfo.TargetType
@@ -70,7 +70,7 @@ namespace ForeverFactory.Generators.Transforms.Factories
 
         private bool CanApplyRecursion(TargetInfo targetInfo)
         {
-            return _options.EnableRecursiveInstantiation && 
+            return Options.EnableRecursiveInstantiation && 
                targetInfo.TargetType != typeof(string) && 
                targetInfo.TargetType != typeof(DateTime);
         }

--- a/src/ForeverFactory/Generators/Transforms/Factories/BaseRecursiveTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/BaseRecursiveTransformFactory.cs
@@ -70,7 +70,9 @@ namespace ForeverFactory.Generators.Transforms.Factories
 
         private bool CanApplyRecursion(TargetInfo targetInfo)
         {
-            return _options.EnableRecursiveInstantiation && targetInfo.TargetType != typeof(string);
+            return _options.EnableRecursiveInstantiation && 
+               targetInfo.TargetType != typeof(string) && 
+               targetInfo.TargetType != typeof(DateTime);
         }
     }
 }

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
@@ -6,7 +6,7 @@ namespace ForeverFactory.Generators.Transforms.Factories
 {
     internal class FillWithSequentialValuesTransformFactory : BaseRecursiveTransformFactory
     {
-        private static DateTime StartingDateTime = new DateTime(
+        public static DateTime StartingDateTime = new DateTime(
             year: 1753, month: 1, day: 1, 
             hour: 0, minute: 0, second: 0,
             kind: DateTimeKind.Utc
@@ -75,6 +75,16 @@ namespace ForeverFactory.Generators.Transforms.Factories
 
                 switch (Options.DateTimeIncrements)
                 {
+                    case DateTimeIncrements.Hours:
+                        return () => StartingDateTime.AddHours(increment);
+                    case DateTimeIncrements.Minutes:
+                        return () => StartingDateTime.AddMinutes(increment);
+                    case DateTimeIncrements.Seconds:
+                        return () => StartingDateTime.AddSeconds(increment);
+                    case DateTimeIncrements.Milliseconds:
+                        return () => StartingDateTime.AddMilliseconds(increment);
+                    case DateTimeIncrements.Ticks:
+                        return () => StartingDateTime.AddTicks(increment);
                     case DateTimeIncrements.Years:
                         return () => StartingDateTime.AddYears(increment);
                     case DateTimeIncrements.Months:

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
@@ -6,6 +6,12 @@ namespace ForeverFactory.Generators.Transforms.Factories
 {
     internal class FillWithSequentialValuesTransformFactory : BaseRecursiveTransformFactory
     {
+        private static DateTime StartingDateTime = new DateTime(
+            year: 1753, month: 1, day: 1, 
+            hour: 0, minute: 0, second: 0,
+            kind: DateTimeKind.Utc
+        );
+
         public FillWithSequentialValuesTransformFactory(RecursiveTransformFactoryOptions options = null) 
             : base(options)
         {
@@ -69,13 +75,14 @@ namespace ForeverFactory.Generators.Transforms.Factories
 
                 switch (Options.DateTimeIncrements)
                 {
+                    case DateTimeIncrements.Years:
+                        return () => StartingDateTime.AddYears(increment);
                     case DateTimeIncrements.Months:
-                        return () => new DateTime(year: 1753, month: 1, day: 1).AddMonths(increment);
+                        return () => StartingDateTime.AddMonths(increment);
                     case DateTimeIncrements.Days:
                     default:
-                        return () => new DateTime(year: 1753, month: 1, day: 1).AddDays(increment);
+                        return () => StartingDateTime.AddDays(increment);
                 }
-                
             }
 
             return null;

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
@@ -62,6 +62,12 @@ namespace ForeverFactory.Generators.Transforms.Factories
             if (targetInfo.TargetType == typeof(decimal))
                 return () => Convert.ToDecimal(sequentialNumber);
 
+            if (targetInfo.TargetType == typeof(DateTime))
+            {
+                var daysToAdd = index;
+                return () => new DateTime(year: 1753, month: 1, day: 1).AddDays(daysToAdd);
+            }
+
             return null;
         }
     }

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ForeverFactory.Behaviors;
 using ForeverFactory.Generators.Transforms.Factories.ReflectionTargets;
 
 namespace ForeverFactory.Generators.Transforms.Factories
@@ -64,8 +65,17 @@ namespace ForeverFactory.Generators.Transforms.Factories
 
             if (targetInfo.TargetType == typeof(DateTime))
             {
-                var daysToAdd = index;
-                return () => new DateTime(year: 1753, month: 1, day: 1).AddDays(daysToAdd);
+                var increment = index;
+
+                switch (Options.DateTimeIncrements)
+                {
+                    case DateTimeIncrements.Months:
+                        return () => new DateTime(year: 1753, month: 1, day: 1).AddMonths(increment);
+                    case DateTimeIncrements.Days:
+                    default:
+                        return () => new DateTime(year: 1753, month: 1, day: 1).AddDays(increment);
+                }
+                
             }
 
             return null;

--- a/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactory.cs
@@ -6,12 +6,6 @@ namespace ForeverFactory.Generators.Transforms.Factories
 {
     internal class FillWithSequentialValuesTransformFactory : BaseRecursiveTransformFactory
     {
-        public static DateTime StartingDateTime = new DateTime(
-            year: 1753, month: 1, day: 1, 
-            hour: 0, minute: 0, second: 0,
-            kind: DateTimeKind.Utc
-        );
-
         public FillWithSequentialValuesTransformFactory(RecursiveTransformFactoryOptions options = null) 
             : base(options)
         {
@@ -76,22 +70,22 @@ namespace ForeverFactory.Generators.Transforms.Factories
                 switch (Options.DateTimeIncrements)
                 {
                     case DateTimeIncrements.Hours:
-                        return () => StartingDateTime.AddHours(increment);
+                        return () => Options.StartDate.AddHours(increment);
                     case DateTimeIncrements.Minutes:
-                        return () => StartingDateTime.AddMinutes(increment);
+                        return () => Options.StartDate.AddMinutes(increment);
                     case DateTimeIncrements.Seconds:
-                        return () => StartingDateTime.AddSeconds(increment);
+                        return () => Options.StartDate.AddSeconds(increment);
                     case DateTimeIncrements.Milliseconds:
-                        return () => StartingDateTime.AddMilliseconds(increment);
+                        return () => Options.StartDate.AddMilliseconds(increment);
                     case DateTimeIncrements.Ticks:
-                        return () => StartingDateTime.AddTicks(increment);
+                        return () => Options.StartDate.AddTicks(increment);
                     case DateTimeIncrements.Years:
-                        return () => StartingDateTime.AddYears(increment);
+                        return () => Options.StartDate.AddYears(increment);
                     case DateTimeIncrements.Months:
-                        return () => StartingDateTime.AddMonths(increment);
+                        return () => Options.StartDate.AddMonths(increment);
                     case DateTimeIncrements.Days:
                     default:
-                        return () => StartingDateTime.AddDays(increment);
+                        return () => Options.StartDate.AddDays(increment);
                 }
             }
 

--- a/src/ForeverFactory/Generators/Transforms/Factories/RecursiveTransformFactoryOptions.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/RecursiveTransformFactoryOptions.cs
@@ -1,7 +1,10 @@
-﻿namespace ForeverFactory.Generators.Transforms.Factories
+﻿using ForeverFactory.Behaviors;
+
+namespace ForeverFactory.Generators.Transforms.Factories
 {
     internal class RecursiveTransformFactoryOptions
     {
         public bool EnableRecursiveInstantiation { get; set; } = true;
+        public DateTimeIncrements DateTimeIncrements { get; set; } = DateTimeIncrements.Days;
     }
 }

--- a/src/ForeverFactory/Generators/Transforms/Factories/RecursiveTransformFactoryOptions.cs
+++ b/src/ForeverFactory/Generators/Transforms/Factories/RecursiveTransformFactoryOptions.cs
@@ -1,10 +1,20 @@
-﻿using ForeverFactory.Behaviors;
+﻿using System;
+using ForeverFactory.Behaviors;
 
 namespace ForeverFactory.Generators.Transforms.Factories
 {
     internal class RecursiveTransformFactoryOptions
     {
+        public static DateTime DefaultStartDate = new DateTime(
+            year: 1753, month: 1, day: 1, 
+            hour: 0, minute: 0, second: 0,
+            kind: DateTimeKind.Utc
+        );
+
         public bool EnableRecursiveInstantiation { get; set; } = true;
+
         public DateTimeIncrements DateTimeIncrements { get; set; } = DateTimeIncrements.Days;
+
+        public DateTime StartDate { get; set; } = DefaultStartDate;
     }
 }

--- a/tests/ForeverFactory.Tests/Behaviors/FillWithSequentialValuesBehaviorTests.cs
+++ b/tests/ForeverFactory.Tests/Behaviors/FillWithSequentialValuesBehaviorTests.cs
@@ -95,6 +95,60 @@ namespace ForeverFactory.Tests.Behaviors
             }
         }
 
+        public class CustomizedDateTimeGenerationTests
+        {
+            private static readonly DateTime StartDate = 25.December(2020).At(22.Hours());
+            private static readonly DateTimeIncrements DateTimeIncrements = DateTimeIncrements.Hours;
+
+            public static IEnumerable<object[]> FactoriesWithDefaultBehavior()
+            {
+                var customerFactoryWithPropertyNameFillingBehavior = new CustomerFactoryWithPropertyNameFillingBehavior();
+                var simpleFactory = MagicFactory.For<Customer>().WithBehavior(GetCustomizedBehavior(
+                    startDate: StartDate, 
+                    increments: DateTimeIncrements
+                ));
+                return new List<object[]>
+                {
+                    new object[] {customerFactoryWithPropertyNameFillingBehavior},
+                    new object[] {simpleFactory}
+                };
+            }
+
+            [Theory]
+            [MemberData(nameof(FactoriesWithDefaultBehavior))]
+            public void It_should_fill_all_objects_properties_with_sequential_numbers(ISimpleFactory<Customer> factory)
+            {
+                var customers = factory.Many(3).Build().ToArray();
+
+                customers[0].Birthday.Should().Be(25.December(2020).At(22.Hours()));
+                customers[1].Birthday.Should().Be(25.December(2020).At(23.Hours()));
+                customers[2].Birthday.Should().Be(26.December(2020).At(0.Hours()));
+            }
+            
+            private class CustomerFactoryWithPropertyNameFillingBehavior : MagicFactory<Customer>
+            {
+                protected override void Customize(ICustomizeFactoryOptions<Customer> customization)
+                {
+                    customization.SetDefaultBehavior(GetCustomizedBehavior(
+                        startDate: StartDate, 
+                        increments: DateTimeIncrements
+                    ));
+                }
+            }
+
+            private static FillWithSequentialValuesBehavior GetCustomizedBehavior(DateTime startDate, DateTimeIncrements increments)
+            {
+                return new FillWithSequentialValuesBehavior(options =>
+                {
+                    options.DateTimeOptions = new DateTimeSequenceOptions
+                    {
+                        StartDate = startDate,
+                        DateTimeIncrements = increments
+                    };
+                });
+            }
+        }
+
         public class Customer
         {
             public string Name { get; set; }

--- a/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
@@ -106,7 +106,7 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
                 var instance = new ClassWithManyDifferentTypesOfProperties();
                 transform.ApplyTo(instance, index);
 
-                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromHours(incrementedHours));
+                instance.DateTimeProperty.Should().Be(RecursiveTransformFactoryOptions.DefaultStartDate.Date + TimeSpan.FromHours(incrementedHours));
             }
             
             [Theory]
@@ -124,7 +124,7 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
                 var instance = new ClassWithManyDifferentTypesOfProperties();
                 transform.ApplyTo(instance, index);
 
-                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromMinutes(incrementedMinutes));
+                instance.DateTimeProperty.Should().Be(RecursiveTransformFactoryOptions.DefaultStartDate.Date + TimeSpan.FromMinutes(incrementedMinutes));
             }
             
             [Theory]
@@ -142,7 +142,7 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
                 var instance = new ClassWithManyDifferentTypesOfProperties();
                 transform.ApplyTo(instance, index);
 
-                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromSeconds(incrementedSeconds));
+                instance.DateTimeProperty.Should().Be(RecursiveTransformFactoryOptions.DefaultStartDate.Date + TimeSpan.FromSeconds(incrementedSeconds));
             }
             
             [Theory]
@@ -160,7 +160,7 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
                 var instance = new ClassWithManyDifferentTypesOfProperties();
                 transform.ApplyTo(instance, index);
 
-                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromMilliseconds(incrementedMilliseconds));
+                instance.DateTimeProperty.Should().Be(RecursiveTransformFactoryOptions.DefaultStartDate.Date + TimeSpan.FromMilliseconds(incrementedMilliseconds));
             }
             
             [Theory]
@@ -178,7 +178,27 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
                 var instance = new ClassWithManyDifferentTypesOfProperties();
                 transform.ApplyTo(instance, index);
 
-                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromTicks(incrementedTicks));
+                instance.DateTimeProperty.Should().Be(RecursiveTransformFactoryOptions.DefaultStartDate.Date + TimeSpan.FromTicks(incrementedTicks));
+            }
+            
+            [Theory]
+            [InlineData(0, 1999, 12, 25, 0)]
+            [InlineData(365, 2012, 12, 31, 365)]
+            public void It_should_generate_sequential_dates_based_on_the_start_date(int index, 
+                int startYear, int startMonth, int startDay, int incrementedDays)
+            {
+                var startDate = new DateTime(startYear, startMonth, startDay);
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Days,
+                        StartDate = startDate
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(startDate + TimeSpan.FromDays(incrementedDays));
             }
         }
 

--- a/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
@@ -1,14 +1,17 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using FluentAssertions.Extensions;
 using ForeverFactory.Generators.Transforms.Factories;
 using Xunit;
 
 namespace ForeverFactory.Tests.Generators.Transforms.Factories
 {
-    public class FillWithPropertyNameTransformFactoryTests
+    public class FillWithSequentialValuesTransformFactoryTests
     {
         private readonly FillWithSequentialValuesTransformFactory _factory;
 
-        public FillWithPropertyNameTransformFactoryTests()
+        public FillWithSequentialValuesTransformFactoryTests()
         {
             _factory = new FillWithSequentialValuesTransformFactory();
         }
@@ -36,6 +39,26 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
             instance.DoubleProperty.Should().Be(sequentialNumberExpected);
             instance.DecimalProperty.Should().Be(sequentialNumberExpected);
         }
+        
+        [Theory]
+        [MemberData(nameof(SequentialDateTimeValues))]
+        public void It_should_fill_datetime_properties_with_sequential_values(int index, DateTime sequentialDateTimeExpected)
+        {
+            var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+            var instance = new ClassWithManyDifferentTypesOfProperties();
+            transform.ApplyTo(instance, index);
+
+            instance.DateTimeProperty.Should().Be(sequentialDateTimeExpected);
+        }
+
+        public static IEnumerable<object[]> SequentialDateTimeValues => 
+            new List<object[]>
+            {
+                new object[] {0, 1.January(1753)},
+                new object[] {1, 2.January(1753)},
+                new object[] {2, 3.January(1753)},
+            };
 
         public class ClassWithManyDifferentTypesOfProperties
         {
@@ -50,6 +73,7 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
             public float FloatProperty { get; set; }
             public double DoubleProperty { get; set; }
             public decimal DecimalProperty { get; set; }
+            public DateTime DateTimeProperty { get; set; }
         }
 
         [Fact]

--- a/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
@@ -91,6 +91,95 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
                 instance.DateTimeProperty.Should().Be(new DateTime(expectedYear, expectedMonth, expectedDay));
             }
             
+            [Theory]
+            [InlineData(0, 0)]
+            [InlineData(1, 1)]
+            [InlineData(2, 2)]
+            public void It_should_generate_sequential_dates_incrementing_by_hour(int index, int incrementedHours)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Hours
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromHours(incrementedHours));
+            }
+            
+            [Theory]
+            [InlineData(0, 0)]
+            [InlineData(1, 1)]
+            [InlineData(2, 2)]
+            public void It_should_generate_sequential_dates_incrementing_by_minute(int index, int incrementedMinutes)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Minutes
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromMinutes(incrementedMinutes));
+            }
+            
+            [Theory]
+            [InlineData(0, 0)]
+            [InlineData(1, 1)]
+            [InlineData(60, 60)]
+            public void It_should_generate_sequential_dates_incrementing_by_seconds(int index, int incrementedSeconds)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Seconds
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromSeconds(incrementedSeconds));
+            }
+            
+            [Theory]
+            [InlineData(0, 0)]
+            [InlineData(1, 1)]
+            [InlineData(1200, 1200)]
+            public void It_should_generate_sequential_dates_incrementing_by_milliseconds(int index, int incrementedMilliseconds)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Milliseconds
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromMilliseconds(incrementedMilliseconds));
+            }
+            
+            [Theory]
+            [InlineData(0, 0)]
+            [InlineData(1, 1)]
+            [InlineData(1000_000, 1000_000)]
+            public void It_should_generate_sequential_dates_incrementing_by_ticks(int index, int incrementedTicks)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Ticks
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(FillWithSequentialValuesTransformFactory.StartingDateTime.Date + TimeSpan.FromTicks(incrementedTicks));
+            }
         }
 
         public class ClassWithManyDifferentTypesOfProperties

--- a/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using FluentAssertions.Extensions;
+using ForeverFactory.Behaviors;
 using ForeverFactory.Generators.Transforms.Factories;
 using Xunit;
 
@@ -36,33 +37,41 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
 
         public class SequentialDateTimeTests
         {
-            private readonly FillWithSequentialValuesTransformFactory _factory;
-
-            public SequentialDateTimeTests()
-            {
-                _factory = new FillWithSequentialValuesTransformFactory();
-            }
-            
             [Theory]
-            [MemberData(nameof(SequentialDateTimeValues))]
-            public void It_should_fill_datetime_properties_with_sequential_values(int index,
-                DateTime sequentialDateTimeExpected)
+            [InlineData(0, 1753, 1, 1)]
+            [InlineData(1, 1753, 1, 2)]
+            [InlineData(2, 1753, 1, 3)]
+            public void It_should_generate_sequential_dates_incrementing_by_day(int index,
+                int expectedYear, int expectedMonth, int expectedDay)
             {
-                var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+                var transform = new FillWithSequentialValuesTransformFactory()
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
 
                 var instance = new ClassWithManyDifferentTypesOfProperties();
                 transform.ApplyTo(instance, index);
 
-                instance.DateTimeProperty.Should().Be(sequentialDateTimeExpected);
+                instance.DateTimeProperty.Should().Be(new DateTime(expectedYear, expectedMonth, expectedDay));
             }
 
-            public static IEnumerable<object[]> SequentialDateTimeValues =>
-                new List<object[]>
-                {
-                    new object[] {0, 1.January(1753)},
-                    new object[] {1, 2.January(1753)},
-                    new object[] {2, 3.January(1753)},
-                };
+            [Theory]
+            [InlineData(0, 1753, 1, 1)]
+            [InlineData(1, 1753, 2, 1)]
+            [InlineData(2, 1753, 3, 1)]
+            public void It_should_generate_sequential_dates_incrementing_by_month(int index,
+                int expectedYear, int expectedMonth, int expectedDay)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Months
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(new DateTime(expectedYear, expectedMonth, expectedDay));
+            }
+            
         }
 
         public class ClassWithManyDifferentTypesOfProperties

--- a/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
@@ -72,6 +72,25 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
                 instance.DateTimeProperty.Should().Be(new DateTime(expectedYear, expectedMonth, expectedDay));
             }
             
+            [Theory]
+            [InlineData(0, 1753, 1, 1)]
+            [InlineData(1, 1754, 1, 1)]
+            [InlineData(2, 1755, 1, 1)]
+            public void It_should_generate_sequential_dates_incrementing_by_year(int index,
+                int expectedYear, int expectedMonth, int expectedDay)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory(new RecursiveTransformFactoryOptions
+                    {
+                        DateTimeIncrements = DateTimeIncrements.Years
+                    })
+                    .GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(new DateTime(expectedYear, expectedMonth, expectedDay));
+            }
+            
         }
 
         public class ClassWithManyDifferentTypesOfProperties

--- a/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
+++ b/tests/ForeverFactory.Tests/Generators/Transforms/Factories/FillWithSequentialValuesTransformFactoryTests.cs
@@ -9,56 +9,61 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
 {
     public class FillWithSequentialValuesTransformFactoryTests
     {
-        private readonly FillWithSequentialValuesTransformFactory _factory;
-
-        public FillWithSequentialValuesTransformFactoryTests()
-        {
-            _factory = new FillWithSequentialValuesTransformFactory();
-        }
-
         [Theory]
         [InlineData(0, 1)]
         [InlineData(1, 2)]
         [InlineData(2, 3)]
         public void It_should_fill_properties_with_sequential_values(int index, int sequentialNumberExpected)
         {
-            var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+            var transform = new FillWithSequentialValuesTransformFactory()
+                .GetTransform<ClassWithManyDifferentTypesOfProperties>();
 
             var instance = new ClassWithManyDifferentTypesOfProperties();
             transform.ApplyTo(instance, index);
 
             instance.StringProperty.Should().Be($"StringProperty{sequentialNumberExpected}");
-            instance.ByteProperty.Should().Be((byte)sequentialNumberExpected, "byte properties should be filled");
-            instance.ShortProperty.Should().Be((short)sequentialNumberExpected);
-            instance.UShortProperty.Should().Be((ushort)sequentialNumberExpected);
+            instance.ByteProperty.Should().Be((byte) sequentialNumberExpected, "byte properties should be filled");
+            instance.ShortProperty.Should().Be((short) sequentialNumberExpected);
+            instance.UShortProperty.Should().Be((ushort) sequentialNumberExpected);
             instance.IntProperty.Should().Be(sequentialNumberExpected);
-            instance.UIntProperty.Should().Be((uint)sequentialNumberExpected);
+            instance.UIntProperty.Should().Be((uint) sequentialNumberExpected);
             instance.LongProperty.Should().Be(sequentialNumberExpected);
-            instance.ULongProperty.Should().Be((ulong)sequentialNumberExpected);
+            instance.ULongProperty.Should().Be((ulong) sequentialNumberExpected);
             instance.FloatProperty.Should().Be(sequentialNumberExpected);
             instance.DoubleProperty.Should().Be(sequentialNumberExpected);
             instance.DecimalProperty.Should().Be(sequentialNumberExpected);
         }
-        
-        [Theory]
-        [MemberData(nameof(SequentialDateTimeValues))]
-        public void It_should_fill_datetime_properties_with_sequential_values(int index, DateTime sequentialDateTimeExpected)
+
+        public class SequentialDateTimeTests
         {
-            var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+            private readonly FillWithSequentialValuesTransformFactory _factory;
 
-            var instance = new ClassWithManyDifferentTypesOfProperties();
-            transform.ApplyTo(instance, index);
-
-            instance.DateTimeProperty.Should().Be(sequentialDateTimeExpected);
-        }
-
-        public static IEnumerable<object[]> SequentialDateTimeValues => 
-            new List<object[]>
+            public SequentialDateTimeTests()
             {
-                new object[] {0, 1.January(1753)},
-                new object[] {1, 2.January(1753)},
-                new object[] {2, 3.January(1753)},
-            };
+                _factory = new FillWithSequentialValuesTransformFactory();
+            }
+            
+            [Theory]
+            [MemberData(nameof(SequentialDateTimeValues))]
+            public void It_should_fill_datetime_properties_with_sequential_values(int index,
+                DateTime sequentialDateTimeExpected)
+            {
+                var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+                transform.ApplyTo(instance, index);
+
+                instance.DateTimeProperty.Should().Be(sequentialDateTimeExpected);
+            }
+
+            public static IEnumerable<object[]> SequentialDateTimeValues =>
+                new List<object[]>
+                {
+                    new object[] {0, 1.January(1753)},
+                    new object[] {1, 2.January(1753)},
+                    new object[] {2, 3.January(1753)},
+                };
+        }
 
         public class ClassWithManyDifferentTypesOfProperties
         {
@@ -76,83 +81,114 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
             public DateTime DateTimeProperty { get; set; }
         }
 
-        [Fact]
-        public void Bytes_should_reset_to_1_when_overflowing()
+        public class NumberOverflowTests
         {
-            var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
-            var instance = new ClassWithManyDifferentTypesOfProperties();
+            private readonly FillWithSequentialValuesTransformFactory _factory;
 
-            transform.ApplyTo(instance, index: byte.MaxValue - 1);
-            instance.ByteProperty.Should().Be(byte.MaxValue);
+            public NumberOverflowTests()
+            {
+                _factory = new FillWithSequentialValuesTransformFactory();
+            }
             
-            transform.ApplyTo(instance, index: byte.MaxValue);
-            instance.ByteProperty.Should().Be(1);
-            
-            transform.ApplyTo(instance, index: byte.MaxValue + 1);
-            instance.ByteProperty.Should().Be(2);
-            
-            transform.ApplyTo(instance, index: byte.MaxValue * 2);
-            instance.ByteProperty.Should().Be(1);
+            [Fact]
+            public void Bytes_should_reset_to_1_when_overflowing()
+            {
+                var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+
+                transform.ApplyTo(instance, index: byte.MaxValue - 1);
+                instance.ByteProperty.Should().Be(byte.MaxValue);
+
+                transform.ApplyTo(instance, index: byte.MaxValue);
+                instance.ByteProperty.Should().Be(1);
+
+                transform.ApplyTo(instance, index: byte.MaxValue + 1);
+                instance.ByteProperty.Should().Be(2);
+
+                transform.ApplyTo(instance, index: byte.MaxValue * 2);
+                instance.ByteProperty.Should().Be(1);
+            }
+
+            [Fact]
+            public void Short_should_reset_to_1_when_overflowing()
+            {
+                var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+
+                transform.ApplyTo(instance, index: short.MaxValue - 1);
+                instance.ShortProperty.Should().Be(short.MaxValue);
+
+                transform.ApplyTo(instance, index: short.MaxValue);
+                instance.ShortProperty.Should().Be(1);
+
+                transform.ApplyTo(instance, index: short.MaxValue + 1);
+                instance.ShortProperty.Should().Be(2);
+
+                transform.ApplyTo(instance, index: short.MaxValue * 2);
+                instance.ShortProperty.Should().Be(1);
+            }
+
+            [Fact]
+            public void UShort_should_reset_to_1_when_overflowing()
+            {
+                var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
+                var instance = new ClassWithManyDifferentTypesOfProperties();
+
+                transform.ApplyTo(instance, index: ushort.MaxValue - 1);
+                instance.UShortProperty.Should().Be(ushort.MaxValue);
+
+                transform.ApplyTo(instance, index: ushort.MaxValue);
+                instance.UShortProperty.Should().Be(1);
+
+                transform.ApplyTo(instance, index: ushort.MaxValue + 1);
+                instance.UShortProperty.Should().Be(2);
+
+                transform.ApplyTo(instance, index: ushort.MaxValue * 2);
+                instance.UShortProperty.Should().Be(1);
+            }
         }
-        
-        [Fact]
-        public void Short_should_reset_to_1_when_overflowing()
+
+        public class RecursionTests
         {
-            var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
-            var instance = new ClassWithManyDifferentTypesOfProperties();
+            [Theory]
+            [InlineData(0, 1)]
+            [InlineData(1, 2)]
+            [InlineData(2, 3)]
+            public void It_should_build_a_function_that_recursively_sets_all_properties_to_the_name_of_the_property(
+                int index, int sequentialNumberExpected)
+            {
+                var transform = new FillWithSequentialValuesTransformFactory().GetTransform<ClassA>();
 
-            transform.ApplyTo(instance, index: short.MaxValue - 1);
-            instance.ShortProperty.Should().Be(short.MaxValue);
-            
-            transform.ApplyTo(instance, index: short.MaxValue);
-            instance.ShortProperty.Should().Be(1);
-            
-            transform.ApplyTo(instance, index: short.MaxValue + 1);
-            instance.ShortProperty.Should().Be(2);
-            
-            transform.ApplyTo(instance, index: short.MaxValue * 2);
-            instance.ShortProperty.Should().Be(1);
-        }
-        
-        [Fact]
-        public void UShort_should_reset_to_1_when_overflowing()
-        {
-            var transform = _factory.GetTransform<ClassWithManyDifferentTypesOfProperties>();
-            var instance = new ClassWithManyDifferentTypesOfProperties();
-            
-            transform.ApplyTo(instance, index: ushort.MaxValue - 1);
-            instance.UShortProperty.Should().Be(ushort.MaxValue);
-            
-            transform.ApplyTo(instance, index: ushort.MaxValue);
-            instance.UShortProperty.Should().Be(1);
-            
-            transform.ApplyTo(instance, index: ushort.MaxValue + 1);
-            instance.UShortProperty.Should().Be(2);
-            
-            transform.ApplyTo(instance, index: ushort.MaxValue * 2);
-            instance.UShortProperty.Should().Be(1);
-        }
-        
-        [Theory]
-        [InlineData(0, 1)]
-        [InlineData(1, 2)]
-        [InlineData(2, 3)]
-        public void It_should_build_a_function_that_recursively_sets_all_properties_to_the_name_of_the_property(int index, int sequentialNumberExpected)
-        {
-            var transform = _factory.GetTransform<ClassA>();
+                var instanceOfA = new ClassA();
+                transform.ApplyTo(instanceOfA, index);
 
-            var instanceOfA = new ClassA();
-            transform.ApplyTo(instanceOfA, index);
+                instanceOfA.PropertyX.Should().Be($"PropertyX{sequentialNumberExpected}");
+                instanceOfA.B.Should().NotBeNull();
 
-            instanceOfA.PropertyX.Should().Be($"PropertyX{sequentialNumberExpected}");
-            instanceOfA.B.Should().NotBeNull();
+                var instanceOfB = instanceOfA.B;
+                instanceOfB.PropertyY.Should().Be($"PropertyY{sequentialNumberExpected}");
+                instanceOfB.C.Should().NotBeNull();
 
-            var instanceOfB = instanceOfA.B;
-            instanceOfB.PropertyY.Should().Be($"PropertyY{sequentialNumberExpected}");
-            instanceOfB.C.Should().NotBeNull();
+                var instanceOfC = instanceOfB.C;
+                instanceOfC.PropertyZ.Should().Be($"PropertyZ{sequentialNumberExpected}");
+            }
             
-            var instanceOfC = instanceOfB.C;
-            instanceOfC.PropertyZ.Should().Be($"PropertyZ{sequentialNumberExpected}");
+            [Fact]
+            public void Should_disable_recursive_fill()
+            {
+                var factoryWithRecursionDisabled = new FillWithSequentialValuesTransformFactory(
+                    new RecursiveTransformFactoryOptions {
+                        EnableRecursiveInstantiation = false
+                    }
+                );
+
+                var transform = factoryWithRecursionDisabled.GetTransform<ClassA>();
+                var instance = new ClassA();
+                transform.ApplyTo(instance);
+
+                instance.PropertyX.Should().Be("PropertyX1");
+                instance.B.Should().Be(null, "should not recursively fill when it is disable via options");
+            }
         }
 
         private class ClassA
@@ -170,23 +206,6 @@ namespace ForeverFactory.Tests.Generators.Transforms.Factories
         private class ClassC
         {
             public string PropertyZ { get; set; }
-        }
-
-        [Fact]
-        public void Should_disable_recursive_fill()
-        {
-            var factoryWithRecursionDisabled = new FillWithSequentialValuesTransformFactory(
-                new RecursiveTransformFactoryOptions {
-                    EnableRecursiveInstantiation = false
-                }
-            );
-
-            var transform = factoryWithRecursionDisabled.GetTransform<ClassA>();
-            var instance = new ClassA();
-            transform.ApplyTo(instance);
-
-            instance.PropertyX.Should().Be("PropertyX1");
-            instance.B.Should().Be(null, "should not recursively fill when it is disable via options");
         }
     }
 }


### PR DESCRIPTION
# Features

- Added support to filling DateTimes when using `FillWithSequentialValuesBehavior`.
- Added new options to customize how DateTime sequences will be generated

## Example configuration

```csharp
var behavior = new FillWithSequentialValuesBehavior(options =>
{
    options.DateTimeOptions = new DateTimeSequenceOptions
    {
        StartDate = new Date(1995, 2, 1),
        DateTimeIncrements = DateTimeIncrements.Days
    };
});

var customers = MagicFactory.For<Customer>()
  .WithBehavior(behavior)
  .Many(3)
  .Build()
  .ToList();

customers[0].Birthday.Should().Be(1.February(1995));
customers[1].Birthday.Should().Be(2.February(1995));
customers[2].Birthday.Should().Be(3.February(1995));
```